### PR TITLE
Update module to use ssacli

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ include ::hpacucli
 Developed and tested on Ubuntu 14.04 server. Pull requests are welcomed. 
 
 ## Release Notes/Contributors/Etc **Optional**
-
+ * 0.3.0 - Module is upgraded to use ssacli rather than hpacucli. Only tested on Ubuntu 16.04
  * 0.2.0 - Module is bugfixed, and tested on Ubuntu 14.04.
  * 0.1.0 - Initial commit. Nothing really works yet.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,9 +16,14 @@
 #
 
 class hpacucli::install {
-  $pkgs = [ 'hpacucli', 'hp-health']
+  $pkgs = [ 'ssacli']
   package { $pkgs:
     ensure  => 'present',
     require => Class['apt::update']
+  }
+
+  $removepkgs = [ 'hpacucli', 'hp-health' ]
+  package { $removepkgs:
+    ensure => 'absent',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-hpacucli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "ntnusky",
   "summary": "Installs the hpacucli repos and toolsets.",
   "license": "Public Domain",
@@ -20,7 +20,8 @@
       "operatingsystemrelease": [
         "10.04",
         "12.04",
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     }
   ],


### PR DESCRIPTION
The hpacucli package is deprecated. This PR will update the module to install ssacli